### PR TITLE
앨범 접근 기능 리팩토링

### DIFF
--- a/PhotoAlbum/PhotoAlbum.xcodeproj/project.pbxproj
+++ b/PhotoAlbum/PhotoAlbum.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		B5C471E027E9692C00E6D827 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B5C471DE27E9692C00E6D827 /* Main.storyboard */; };
 		B5C471E227E9692E00E6D827 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B5C471E127E9692E00E6D827 /* Assets.xcassets */; };
 		B5C471E527E9692E00E6D827 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B5C471E327E9692E00E6D827 /* LaunchScreen.storyboard */; };
+		B5DC626D27EC3BF1005087C6 /* CustomPhotoManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DC626C27EC3BF1005087C6 /* CustomPhotoManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -26,6 +27,7 @@
 		B5C471E127E9692E00E6D827 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		B5C471E427E9692E00E6D827 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		B5C471E627E9692E00E6D827 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B5DC626C27EC3BF1005087C6 /* CustomPhotoManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPhotoManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -63,6 +65,7 @@
 				B5C471DC27E9692C00E6D827 /* ViewController.swift */,
 				B5C471DE27E9692C00E6D827 /* Main.storyboard */,
 				6F31E9FD27E9979A00659880 /* CustomCollectionViewCell.swift */,
+				B5DC626C27EC3BF1005087C6 /* CustomPhotoManager.swift */,
 				B5C471E127E9692E00E6D827 /* Assets.xcassets */,
 				B5C471E327E9692E00E6D827 /* LaunchScreen.storyboard */,
 				B5C471E627E9692E00E6D827 /* Info.plist */,
@@ -144,6 +147,7 @@
 				B5C471DD27E9692C00E6D827 /* ViewController.swift in Sources */,
 				B5C471D927E9692C00E6D827 /* AppDelegate.swift in Sources */,
 				B5C471DB27E9692C00E6D827 /* SceneDelegate.swift in Sources */,
+				B5DC626D27EC3BF1005087C6 /* CustomPhotoManager.swift in Sources */,
 				6F31E9FE27E9979A00659880 /* CustomCollectionViewCell.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PhotoAlbum/PhotoAlbum/CustomPhotoManager.swift
+++ b/PhotoAlbum/PhotoAlbum/CustomPhotoManager.swift
@@ -1,0 +1,5 @@
+import Foundation
+import Photos
+
+class CustomPhotoManager: NSObject, PHPhotoLibraryChangeObserver{
+}

--- a/PhotoAlbum/PhotoAlbum/CustomPhotoManager.swift
+++ b/PhotoAlbum/PhotoAlbum/CustomPhotoManager.swift
@@ -15,4 +15,84 @@ class CustomPhotoManager: NSObject, PHPhotoLibraryChangeObserver{
         static let  authorizationDeniedAlert = Notification.Name("authorizationDeniedAlert")
     }
     
+    let manager = PHCachingImageManager()
+    let option = PHImageRequestOptions()
+    var images: PHAssetCollection?
+    var assets: [PHAsset] = []
+    
+    deinit {
+        PHPhotoLibrary.shared().unregisterChangeObserver(self)
+    }
+    
+    override init(){
+        super.init()
+        PHPhotoLibrary.shared().register(self)
+        self.option.isSynchronous = true
+    }
+    
+    func getAssetCount()->Int{
+        guard let images = self.images else { return 0 }
+        return PHAsset.fetchAssets(in: images, options: nil).count
+    }
+    
+    func getAuthorization() {
+        if isAlbumAcessAuthorized() {
+            fetchAssetCollection()
+        } else if isAlbumAccessDenied() {
+            self.setAuthAlertAction()
+        } else {
+            PHPhotoLibrary.requestAuthorization() { (status) in
+                self.getAuthorization()
+            }
+        }
+    }
+    
+    func fetchAssetCollection() {
+        PHAssetCollection.fetchAssetCollections(with: PHAssetCollectionType.smartAlbum, subtype: PHAssetCollectionSubtype.smartAlbumUserLibrary, options: PHFetchOptions()).enumerateObjects { (collection, _, _) in
+            self.images = collection
+        }
+        self.fetchAsset()
+    }
+    
+    func fetchAsset() {
+        guard let images = self.images else {
+            return
+        }
+        
+        let fetchOptions = PHFetchOptions()
+        fetchOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
+        PHAsset.fetchAssets(in: images, options: fetchOptions).enumerateObjects({ (asset, _, _) in
+            self.assets.append(asset)
+        })
+        
+    }
+    
+    
+    func isAlbumAcessAuthorized() -> Bool {
+        return PHPhotoLibrary.authorizationStatus() == .authorized || PHPhotoLibrary.authorizationStatus() == .limited
+    }
+    
+    func isAlbumAccessDenied() -> Bool {
+        return PHPhotoLibrary.authorizationStatus() == .denied
+    }
+    
+    func photoLibraryDidChange(_ changeInstance: PHChange) {
+        var userInfo: [UserInfoKey:Any] = [:]
+        userInfo[UserInfoKey.alertTitle] = "옵저버가 변화를 감지했습니다!"
+        userInfo[UserInfoKey.alertMessage] = "아직 무슨 변화인지는 몰라요!"
+        userInfo[UserInfoKey.actionTitle] = "OK!"
+        userInfo[UserInfoKey.settingActionHandler] = false
+        
+        NotificationCenter.default.post(name: NotificationName.authorizationDeniedAlert, object: self, userInfo: userInfo)
+    }
+    
+    func setAuthAlertAction() {
+        var userInfo: [UserInfoKey:Any] = [:]
+        userInfo[UserInfoKey.alertTitle] = "사진 앨범 권한 요청"
+        userInfo[UserInfoKey.alertMessage] = "사진첩 권한을 허용해야만 기능을 사용하실 수 있습니다."
+        userInfo[UserInfoKey.actionTitle] = "넵"
+        userInfo[UserInfoKey.settingActionHandler] = true
+        
+        NotificationCenter.default.post(name: NotificationName.authorizationDeniedAlert, object: self, userInfo: userInfo)
+    }
 }

--- a/PhotoAlbum/PhotoAlbum/CustomPhotoManager.swift
+++ b/PhotoAlbum/PhotoAlbum/CustomPhotoManager.swift
@@ -15,10 +15,10 @@ class CustomPhotoManager: NSObject, PHPhotoLibraryChangeObserver{
         static let  authorizationDeniedAlert = Notification.Name("authorizationDeniedAlert")
     }
     
-    let manager = PHCachingImageManager()
-    let option = PHImageRequestOptions()
-    var images: PHAssetCollection?
-    var assets: [PHAsset] = []
+    private let manager = PHCachingImageManager()
+    private let option = PHImageRequestOptions()
+    private var images: PHAssetCollection?
+    private var assets: [PHAsset] = []
     var imageData: [Data] = []
     
     deinit {

--- a/PhotoAlbum/PhotoAlbum/CustomPhotoManager.swift
+++ b/PhotoAlbum/PhotoAlbum/CustomPhotoManager.swift
@@ -2,4 +2,17 @@ import Foundation
 import Photos
 
 class CustomPhotoManager: NSObject, PHPhotoLibraryChangeObserver{
+    
+    enum UserInfoKey: String{
+        case authorizationDeniedAlert = "authorizationDeniedAlert"
+        case alertTitle = "alertTitle"
+        case alertMessage = "alertMessage"
+        case actionTitle = "actionTitle"
+        case settingActionHandler = "settingActionHandler"
+    }
+    
+    struct NotificationName{
+        static let  authorizationDeniedAlert = Notification.Name("authorizationDeniedAlert")
+    }
+    
 }

--- a/PhotoAlbum/PhotoAlbum/CustomPhotoManager.swift
+++ b/PhotoAlbum/PhotoAlbum/CustomPhotoManager.swift
@@ -19,6 +19,7 @@ class CustomPhotoManager: NSObject, PHPhotoLibraryChangeObserver{
     let option = PHImageRequestOptions()
     var images: PHAssetCollection?
     var assets: [PHAsset] = []
+    var imageData: [Data] = []
     
     deinit {
         PHPhotoLibrary.shared().unregisterChangeObserver(self)
@@ -65,8 +66,17 @@ class CustomPhotoManager: NSObject, PHPhotoLibraryChangeObserver{
             self.assets.append(asset)
         })
         
+        self.requestUIImage()
     }
     
+    func requestUIImage(){
+        for index in 0..<assets.count{
+            manager.requestImageDataAndOrientation(for: assets[index], options: option, resultHandler: {(data, _, _, _)-> Void in
+                guard let data = data else { return }
+                self.imageData.append(data)
+            })
+        }
+    }
     
     func isAlbumAcessAuthorized() -> Bool {
         return PHPhotoLibrary.authorizationStatus() == .authorized || PHPhotoLibrary.authorizationStatus() == .limited

--- a/PhotoAlbum/PhotoAlbum/ViewController.swift
+++ b/PhotoAlbum/PhotoAlbum/ViewController.swift
@@ -1,12 +1,8 @@
 import UIKit
-import Photos
 
 class ViewController: UIViewController {
+
     @IBOutlet weak var collectionView: UICollectionView!
-    
-    deinit {
-        PHPhotoLibrary.shared().unregisterChangeObserver(self)
-    }
     private var customPhotoManager: CustomPhotoManager = CustomPhotoManager()
     
     override func viewDidLoad() {
@@ -52,16 +48,7 @@ extension ViewController: UICollectionViewDataSource, UICollectionViewDelegateFl
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "CustomCollectionViewCell", for: indexPath) as! CustomCollectionViewCell
-        
-        let manager = PHCachingImageManager()
-        let option = PHImageRequestOptions()
-        option.isSynchronous = true
-        
-        manager
-            .requestImage(for: assets[indexPath.row], targetSize: CGSize(width: 100, height: 100), contentMode: .aspectFill, options: option, resultHandler: {(result, info) ->  Void in
-                cell.imageView.image = result
-            })
-        
+        cell.imageView.image = UIImage(data: self.customPhotoManager.imageData[indexPath.row])
         return cell
     }
     

--- a/PhotoAlbum/PhotoAlbum/ViewController.swift
+++ b/PhotoAlbum/PhotoAlbum/ViewController.swift
@@ -14,6 +14,7 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        initializeNotificationCenter()
         
         self.collectionView.register(CustomCollectionViewCell.self, forCellWithReuseIdentifier: "CustomCollectionViewCell")
         self.collectionView.delegate = self
@@ -33,6 +34,8 @@ class ViewController: UIViewController {
                 self.getAuthorization()
             }
         }
+    private func initializeNotificationCenter(){
+        NotificationCenter.default.addObserver(self, selector: #selector(presentAlert(_:)), name: CustomPhotoManager.NotificationName.authorizationDeniedAlert, object: self.customPhotoManager)
     }
     
     func setAuthAlertAction() {


### PR DESCRIPTION
### 작업 내용
- [x] viewController와 photo manager 클래스 분리
- [x] customPhotoManager 클래스 생성
- [x] notification center 이용하여 alert 함수 분리
- [x] photos 관련 함수 이동
    - cellForItemAt() 메소드 부분에서 manager.requestImage() 부분 분리
- [x] 뷰컨트롤러에서 getAuthorization() 한 후, 최초 한번만 asset을 이미지 data로 바꾼 배열을 받아서 UIImage 저장
- [x] cellForItemAt() 메소드에서는 처음 받은 배열을 이용하여 cell에 그릴 때마다 사용

*** 지난 번에 주신 피드백 반영해서 리팩토링 했습니다! 피드백 부탁드립니다. :)