### PR TITLE
JSON 파일 파싱 및 이미지 다운로드 기능 리팩토링

### DIFF
--- a/PhotoAlbum/PhotoAlbum/CustomImageDownloadManager.swift
+++ b/PhotoAlbum/PhotoAlbum/CustomImageDownloadManager.swift
@@ -1,26 +1,60 @@
 import Foundation
+import OSLog
+
+enum ImageDownloadingError: Error{
+    case gettingJSONDataError
+    case parsingJSONDataError
+    case downloadingImageDataError
+}
 
 class CustomImageDownloadManager {
+    
     private (set) var imageData: [Data] = []
-
-    func parsingDoodleData() {
+    private var logger: Logger = Logger()
+    
+    func parseDoodleData(){
         guard let fileLocation = Bundle.main.url(forResource: "doodle", withExtension: "json") else { return }
+        do{
+            let data = try getJSONData(fileLocation: fileLocation)
+            let doodleList = try decodeJSONData(data: data)
+            try convertDoodleToImage(doodleList)
+        }catch ImageDownloadingError.gettingJSONDataError{
+            logger.error("JSONDataDownloadingException")
+        }catch ImageDownloadingError.parsingJSONDataError{
+            logger.error("JSONDataParsingException ")
+        }catch ImageDownloadingError.downloadingImageDataError{
+            logger.error("ImageDataDownloadingException")
+        }catch{
+            logger.error("UnDesignatedException : \(error.localizedDescription)")
+        }
         
-        do {
+    }
+    
+    private func getJSONData(fileLocation: URL) throws -> Data{
+        do{
             let data = try Data(contentsOf: fileLocation)
-            let doodleList = try JSONDecoder().decode([Doodle].self, from: data)
-            convertDoodleToImage(doodleList)
-        } catch {
-            print(error)
+            return data
+        }catch{
+            throw ImageDownloadingError.gettingJSONDataError
         }
     }
     
-    private func convertDoodleToImage(_ list: [Doodle]) {
-        list.forEach {
+    private func decodeJSONData(data: Data) throws -> [Doodle]{
+        do{
+            let doodleList = try JSONDecoder().decode([Doodle].self, from: data)
+            return doodleList
+        }catch{
+            throw ImageDownloadingError.parsingJSONDataError
+        }
+    }
+    
+    private func convertDoodleToImage(_ list: [Doodle]) throws {
+        try list.forEach {
+
             let url = URL(string: $0.image)!
-            if let data = try? Data(contentsOf: url) {
-                imageData.append(data)
-            }
+            guard let data = try? Data(contentsOf: url) else { throw ImageDownloadingError.downloadingImageDataError }
+            imageData.append(data)
         }
     }
 }
+

--- a/PhotoAlbum/PhotoAlbum/CustomImageDownloadManager.swift
+++ b/PhotoAlbum/PhotoAlbum/CustomImageDownloadManager.swift
@@ -4,7 +4,6 @@ import OSLog
 enum ImageDownloadingError: Error{
     case gettingJSONDataError
     case parsingJSONDataError
-    case downloadingImageDataError
 }
 
 class CustomImageDownloadManager {
@@ -19,11 +18,9 @@ class CustomImageDownloadManager {
             let doodleList = try decodeJSONData(data: data)
             try convertDoodleToImage(doodleList)
         }catch ImageDownloadingError.gettingJSONDataError{
-            logger.error("JSONDataDownloadingException")
+             logger.error("JSONDataDownloadingException")
         }catch ImageDownloadingError.parsingJSONDataError{
             logger.error("JSONDataParsingException ")
-        }catch ImageDownloadingError.downloadingImageDataError{
-            logger.error("ImageDataDownloadingException")
         }catch{
             logger.error("UnDesignatedException : \(error.localizedDescription)")
         }
@@ -49,12 +46,37 @@ class CustomImageDownloadManager {
     }
     
     private func convertDoodleToImage(_ list: [Doodle]) throws {
-        try list.forEach {
-
+        list.forEach {
             let url = URL(string: $0.image)!
-            guard let data = try? Data(contentsOf: url) else { throw ImageDownloadingError.downloadingImageDataError }
-            imageData.append(data)
+            var urlRequest = URLRequest(url: url)
+            urlRequest.httpMethod = "GET"
+            DispatchQueue.main.async {
+                self.sendURLRequest(urlRequest: urlRequest)
+            }
         }
+    }
+    
+    private func sendURLRequest(urlRequest: URLRequest){
+        URLSession.shared.dataTask(with: urlRequest){ data, response, error in
+            guard error == nil else {
+                self.logger.error("\(error.debugDescription)")
+                return
+            }
+            guard let data = data else {
+                self.logger.error("data not received")
+                return
+            }
+            guard let response = response as? HTTPURLResponse else {
+                self.logger.error("http response not received")
+                return
+            }
+            
+            if(response.statusCode >= 400){
+                self.logger.debug("detected response with 404 status \nurl : \(urlRequest)")
+            }else{
+                self.imageData.append(data)
+            }
+        }.resume()
     }
 }
 

--- a/PhotoAlbum/PhotoAlbum/CustomPhotoManager.swift
+++ b/PhotoAlbum/PhotoAlbum/CustomPhotoManager.swift
@@ -19,7 +19,6 @@ class CustomPhotoManager: NSObject, PHPhotoLibraryChangeObserver{
     private let option = PHImageRequestOptions()
     private var images: PHAssetCollection?
     private var assets: [PHAsset] = []
-    private (set) var imageData: [Data] = []
     
     deinit {
         PHPhotoLibrary.shared().unregisterChangeObserver(self)
@@ -65,17 +64,15 @@ class CustomPhotoManager: NSObject, PHPhotoLibraryChangeObserver{
         PHAsset.fetchAssets(in: images, options: fetchOptions).enumerateObjects({ (asset, _, _) in
             self.assets.append(asset)
         })
-        
-        self.requestUIImage()
     }
     
-    func requestUIImage(){
-        for index in 0..<assets.count{
-            manager.requestImageDataAndOrientation(for: assets[index], options: option, resultHandler: {(data, _, _, _)-> Void in
-                guard let data = data else { return }
-                self.imageData.append(data)
-            })
-        }
+    func requestImageData(index: Int)-> Data?{
+        var imageData: Data?
+        manager.requestImageDataAndOrientation(for: assets[index], options: option, resultHandler: {(data, _, _, _)-> Void in
+            guard let data = data else { return }
+            imageData = data
+        })
+        return imageData
     }
     
     func isAlbumAcessAuthorized() -> Bool {

--- a/PhotoAlbum/PhotoAlbum/CustomPhotoManager.swift
+++ b/PhotoAlbum/PhotoAlbum/CustomPhotoManager.swift
@@ -89,7 +89,7 @@ class CustomPhotoManager: NSObject, PHPhotoLibraryChangeObserver{
     func photoLibraryDidChange(_ changeInstance: PHChange) {
         var userInfo: [UserInfoKey:Any] = [:]
         userInfo[UserInfoKey.alertTitle] = "옵저버가 변화를 감지했습니다!"
-        userInfo[UserInfoKey.alertMessage] = "아직 무슨 변화인지는 몰라요!"
+        userInfo[UserInfoKey.alertMessage] = "컬렉션뷰를 업데이트합니다."
         userInfo[UserInfoKey.actionTitle] = "OK!"
         userInfo[UserInfoKey.settingActionHandler] = false
         

--- a/PhotoAlbum/PhotoAlbum/DoodleViewController.swift
+++ b/PhotoAlbum/PhotoAlbum/DoodleViewController.swift
@@ -8,22 +8,16 @@ class DoodleViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        self.customImageDownloadManager.parseDoodleData()
+        
+        self.collectionView.backgroundColor = .darkGray
         self.view.backgroundColor = .darkGray
         self.navigationItem.title = "Doodle"
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Close", style: .done, target: self, action: #selector(dismissView))
-        
-        DispatchQueue.main.async {
-            DispatchQueue.global().sync {
-                self.customImageDownloadManager.parsingDoodleData()
-                self.downloadedImage = self.customImageDownloadManager.imageData.map { UIImage(data: $0) ?? UIImage() }
-            }
-            
-            self.collectionView.register(CustomDoodleCollectionViewCell.self, forCellWithReuseIdentifier: "CustomDoodleCollectionViewCell")
-            self.collectionView.delegate = self
-            self.collectionView.dataSource = self
-        }
-        
+      
+        self.collectionView.register(CustomDoodleCollectionViewCell.self, forCellWithReuseIdentifier: "CustomDoodleCollectionViewCell")
+        self.collectionView.delegate = self
+        self.collectionView.dataSource = self
     }
     
     @objc func dismissView() {

--- a/PhotoAlbum/PhotoAlbum/DoodleViewController.swift
+++ b/PhotoAlbum/PhotoAlbum/DoodleViewController.swift
@@ -4,16 +4,15 @@ class DoodleViewController: UIViewController {
     
     @IBOutlet weak var collectionView: UICollectionView!
     private var customImageDownloadManager: CustomImageDownloadManager = CustomImageDownloadManager()
-    private var downloadedImage: [UIImage] = []
-    
-    override func viewWillAppear(_ animated: Bool) {
-        self.downloadedImage = self.customImageDownloadManager.imageData.map { UIImage(data: $0) ?? UIImage() }
-        self.collectionView.reloadData()
-    }
         
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.customImageDownloadManager.parseDoodleData()
+        
+        self.customImageDownloadManager.parseDoodleData{
+            DispatchQueue.main.async {
+                self.collectionView.reloadData()
+            }
+        }
         
         self.collectionView.backgroundColor = .darkGray
         self.view.backgroundColor = .darkGray
@@ -33,12 +32,13 @@ class DoodleViewController: UIViewController {
 extension DoodleViewController: UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return downloadedImage.count
+        return self.customImageDownloadManager.imageCount
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "CustomDoodleCollectionViewCell", for: indexPath) as! CustomDoodleCollectionViewCell
-        cell.imageView.image = downloadedImage[indexPath.row]
+        let imageData = self.customImageDownloadManager.getImageData(index: indexPath.row)
+        cell.imageView.image = UIImage(data: imageData)
         return cell
     }
     

--- a/PhotoAlbum/PhotoAlbum/DoodleViewController.swift
+++ b/PhotoAlbum/PhotoAlbum/DoodleViewController.swift
@@ -6,6 +6,11 @@ class DoodleViewController: UIViewController {
     private var customImageDownloadManager: CustomImageDownloadManager = CustomImageDownloadManager()
     private var downloadedImage: [UIImage] = []
     
+    override func viewWillAppear(_ animated: Bool) {
+        self.downloadedImage = self.customImageDownloadManager.imageData.map { UIImage(data: $0) ?? UIImage() }
+        self.collectionView.reloadData()
+    }
+        
     override func viewDidLoad() {
         super.viewDidLoad()
         self.customImageDownloadManager.parseDoodleData()

--- a/PhotoAlbum/PhotoAlbum/ViewController.swift
+++ b/PhotoAlbum/PhotoAlbum/ViewController.swift
@@ -14,7 +14,7 @@ class ViewController: UIViewController {
         self.collectionView.delegate = self
         self.collectionView.dataSource = self
         self.customPhotoManager.getAuthorization()
-        self.doodleViewController = self.storyboard?.instantiateViewController(withIdentifier: "DoodleViewController") as! DoodleViewController
+        self.doodleViewController = self.storyboard?.instantiateViewController(withIdentifier: "DoodleViewController") as? DoodleViewController
     }
     
     @IBAction func addButtonTouched(_ sender: UIBarButtonItem) {
@@ -43,7 +43,9 @@ class ViewController: UIViewController {
         
         authAlert.addAction(getAuthAction)
         DispatchQueue.main.async {
-            self.present(authAlert, animated: true, completion: nil)
+            self.present(authAlert, animated: true, completion: {
+                self.collectionView.reloadData()
+            })
         }
     }
 }

--- a/PhotoAlbum/PhotoAlbum/ViewController.swift
+++ b/PhotoAlbum/PhotoAlbum/ViewController.swift
@@ -58,7 +58,9 @@ extension ViewController: UICollectionViewDataSource, UICollectionViewDelegateFl
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "CustomCollectionViewCell", for: indexPath) as! CustomCollectionViewCell
-        cell.imageView.image = UIImage(data: self.customPhotoManager.imageData[indexPath.row])
+        if let imageData: Data = self.customPhotoManager.requestImageData(index: indexPath.row){
+            cell.imageView.image = UIImage(data: imageData)
+        }
         return cell
     }
     


### PR DESCRIPTION
- [x] parsingDoodleData() 내부 예외처리 로직 수정
    - 사용자 정의 예외 별도로 정의한 후, 개별 로직 수행할 때마다 이에 해당하는 예외를 throw 하도록 수정 
- [x] 이미지 다운로드 Data(contentsOf:) 사용하지 않도록 수정
    - Data 대신 URLSession 사용해서 GET 요청을 보내서 이미지 데이터 응답 받도록 수정 
- [x] imageData 속성 중복 제거
    - CustomPhotoManager 내부에서 불필요하게 Data 타입 배열 가지고 있던 부분 수정
    - 해당 속성 제거 후, 필요 시에는 인덱스값을 파라미터로 받아서 PHAsset 배열에서 이에 해당하는 요소 찾아서 Data 타입 추출하는 함수를 호출하도록 수정
- [x] CustomImageDownloadManager 내부 GCD 사용 개선
    - DispatchQueue.main.async의 사용을 뷰컨트롤러가 아닌, CustomImageDownloadManager 내부의 URLSession 응답 처리하는 로직에 적용하도록 수정 